### PR TITLE
Removed address shifting

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -670,7 +670,7 @@ where
         let enables = self.get_sequence_step_enables()?;
         let timeouts = self.get_sequence_step_timeouts(&enables)?;
 
-        let mut use_budget_microseconds: u32 = (start_overhead + end_overhead) as u32;
+        let mut use_budget_microseconds: u32 = start_overhead + end_overhead;
         if enables.tcc {
             use_budget_microseconds += timeouts.msrc_dss_tcc_microseconds + tcc_overhead;
         }
@@ -739,7 +739,7 @@ struct SeqStepTimeouts {
 }
 
 fn decode_timeout(register_value: u16) -> u16 {
-    ((register_value & 0x00FF) << (((register_value & 0xFF00) as u16) >> 8)) as u16 + 1
+    ((register_value & 0x00FF) << ((register_value & 0xFF00) >> 8)) + 1
 }
 
 fn encode_timeout(timeout_mclks: u16) -> u16 {
@@ -764,13 +764,13 @@ fn calc_macro_period(vcsel_period_pclks: u8) -> u32 {
 }
 
 fn timeout_mclks_to_microseconds(timeout_period_mclks: u16, vcsel_period_pclks: u8) -> u32 {
-    let macro_period_nanoseconds: u32 = calc_macro_period(vcsel_period_pclks) as u32;
+    let macro_period_nanoseconds: u32 = calc_macro_period(vcsel_period_pclks);
     (((timeout_period_mclks as u32) * macro_period_nanoseconds) + (macro_period_nanoseconds / 2))
         / 1000
 }
 
 fn timeout_microseconds_to_mclks(timeout_period_microseconds: u32, vcsel_period_pclks: u8) -> u32 {
-    let macro_period_nanoseconds: u32 = calc_macro_period(vcsel_period_pclks) as u32;
+    let macro_period_nanoseconds: u32 = calc_macro_period(vcsel_period_pclks);
 
     ((timeout_period_microseconds * 1000) + (macro_period_nanoseconds / 2))
         / macro_period_nanoseconds

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -670,7 +670,7 @@ where
         let enables = self.get_sequence_step_enables()?;
         let timeouts = self.get_sequence_step_timeouts(&enables)?;
 
-        let mut use_budget_microseconds: u32 = start_overhead + end_overhead;
+        let mut use_budget_microseconds = start_overhead + end_overhead;
         if enables.tcc {
             use_budget_microseconds += timeouts.msrc_dss_tcc_microseconds + tcc_overhead;
         }
@@ -764,13 +764,13 @@ fn calc_macro_period(vcsel_period_pclks: u8) -> u32 {
 }
 
 fn timeout_mclks_to_microseconds(timeout_period_mclks: u16, vcsel_period_pclks: u8) -> u32 {
-    let macro_period_nanoseconds: u32 = calc_macro_period(vcsel_period_pclks);
+    let macro_period_nanoseconds = calc_macro_period(vcsel_period_pclks);
     (((timeout_period_mclks as u32) * macro_period_nanoseconds) + (macro_period_nanoseconds / 2))
         / 1000
 }
 
 fn timeout_microseconds_to_mclks(timeout_period_microseconds: u32, vcsel_period_pclks: u8) -> u32 {
-    let macro_period_nanoseconds: u32 = calc_macro_period(vcsel_period_pclks);
+    let macro_period_nanoseconds = calc_macro_period(vcsel_period_pclks);
 
     ((timeout_period_microseconds * 1000) + (macro_period_nanoseconds / 2))
         / macro_period_nanoseconds

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,7 +60,10 @@ impl<I2C, E> VL53L0X<I2C>
 where
     I2C: WriteRead<Error = E> + Write<Error = E> + Read<Error = E>,
 {
-    /// Creates a sensor with default configuration
+    /// Creates a sensor with default configuration.
+    ///
+    /// Sometimes it is necessary to shift the address by one place. Use `new()` constructor for this purpose:
+    /// `VL53L0X::new(i2c, 0x29 << 1, true)`
     pub fn default(i2c: I2C) -> Result<VL53L0X<I2C>, Error<E>> {
         VL53L0X::new(i2c, ADDRESS_DEFAULT, true)
     }
@@ -72,7 +75,7 @@ where
             io_mode2v8,
             stop_variable: 0,
             measurement_timing_budget_microseconds: 0,
-            address: address << 1,
+            address,
         };
 
         let wai = chip.who_am_i()?;
@@ -234,7 +237,7 @@ where
     pub fn set_device_address(&mut self, address: u8) -> Result<bool, E> {
         match self.write_only_register(Register::REG_I2C_SLAVE_DEVICE_ADDRESS, address) {
             Ok(_) => {
-                self.address = address << 1;
+                self.address = address;
                 Ok(true)
             }
             Err(e) => Err(e),


### PR DESCRIPTION
Removed address shifting, as discussed in #10. 
Furthermore, Clippy complained regarding some unnecessary castings, which have been removed as well.